### PR TITLE
Use 8.14 and MathComp 1.13.0 in CI

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -20,6 +20,7 @@ jobs:
       matrix:
         image:
           - 'mathcomp/mathcomp-dev:coq-dev'
+          - 'mathcomp/mathcomp:1.13.0-coq-8.14'
           - 'mathcomp/mathcomp:1.12.0-coq-8.13'
           - 'mathcomp/mathcomp:1.11.0-coq-8.12'
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ of said algorithm.
 - Coq-community maintainer(s):
   - Christian Doczkal ([**@chdoc**](https://github.com/chdoc))
 - License: [CeCILL-B](LICENSE)
-- Compatible Coq versions: 8.10 or later
+- Compatible Coq versions: 8.12 or later
 - Additional dependencies:
   - [MathComp](https://math-comp.github.io) 1.10.0 or later (`ssreflect` suffices)
 - Coq namespace: `CompDecModal`

--- a/_CoqProject
+++ b/_CoqProject
@@ -3,6 +3,7 @@
 -arg -w -arg -notation-overridden
 -arg -w -arg -redundant-canonical-projection
 -arg -w -arg -notation-incompatible-format
+-arg -w -arg -deprecated-instance-without-locality
 
 -Q theories CompDecModal
 

--- a/coq-comp-dec-modal.opam
+++ b/coq-comp-dec-modal.opam
@@ -29,10 +29,10 @@ decidability results then follow with soundness from the existence
 of said algorithm.
   """
 
-build: [make "-j%{jobs}%" ]
+build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.12" & < "8.14~") | (= "dev")}
+  "coq" {(>= "8.12" & < "8.15~") | (= "dev")}
   "coq-mathcomp-ssreflect" {(>= "1.10" & < "1.14~") | (= "dev")}
 ]
 

--- a/meta.yml
+++ b/meta.yml
@@ -52,12 +52,14 @@ license:
   identifier: CECILL-B
 
 supported_coq_versions:
-  text: 8.10 or later
-  opam: '{(>= "8.12" & < "8.14~") | (= "dev")}'
+  text: 8.12 or later
+  opam: '{(>= "8.12" & < "8.15~") | (= "dev")}'
 
 tested_coq_opam_versions:
 - version: 'coq-dev'
   repo: 'mathcomp/mathcomp-dev'
+- version: '1.13.0-coq-8.14'
+  repo: 'mathcomp/mathcomp'
 - version: '1.12.0-coq-8.13'
   repo: 'mathcomp/mathcomp'
 - version: '1.11.0-coq-8.12'

--- a/theories/dune
+++ b/theories/dune
@@ -2,6 +2,11 @@
  (name CompDecModal)
  (package coq-comp-dec-modal)
  (synopsis "Constructive proofs of soundness and completeness for K, K*, CTL, PDL, and PDL with converse")
- (flags -w -projection-no-head-constant -w -notation-overridden -w -redundant-canonical-projection -w -notation-incompatible-format))
+ (flags :standard
+   -w -projection-no-head-constant
+   -w -notation-overridden
+   -w -redundant-canonical-projection
+   -w -notation-incompatible-format
+   -w -deprecated-instance-without-locality))
 
 (include_subdirs qualified)


### PR DESCRIPTION
Regenerate boilerplate and suppress unfixable warning.

Since release 1.0 does not build with 8.14 (due to dropping omega), any chance for a new release after this is merged?