### PR TITLE
compatibility with Coq 8.21 and later

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -19,6 +19,7 @@ jobs:
     strategy:
       matrix:
         image:
+          - 'mathcomp/mathcomp-dev:coq-dev'
           - 'mathcomp/mathcomp:2.2.0-coq-8.19'
           - 'mathcomp/mathcomp:2.2.0-coq-8.18'
           - 'mathcomp/mathcomp:2.2.0-coq-8.17'

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ of said algorithm.
 - Coq-community maintainer(s):
   - Christian Doczkal ([**@chdoc**](https://github.com/chdoc))
 - License: [CeCILL-B](LICENSE)
-- Compatible Coq versions: 8.16 to 8.20
+- Compatible Coq versions: 8.16 or later
 - Additional dependencies:
   - [MathComp](https://math-comp.github.io) 2.0 or later (`ssreflect` suffices)
   - [Hierarchy Builder](https://github.com/math-comp/hierarchy-builder) 1.6.0 or later

--- a/coq-comp-dec-modal.opam
+++ b/coq-comp-dec-modal.opam
@@ -32,7 +32,7 @@ of said algorithm.
 build: [make "-j%{jobs}%"]
 install: [make "install"]
 depends: [
-  "coq" {>= "8.16" & < "8.21"}
+  "coq" {>= "8.16"}
   "coq-mathcomp-ssreflect" {>= "2.0"}
   "coq-hierarchy-builder" {>= "1.6.0"}
 ]

--- a/meta.yml
+++ b/meta.yml
@@ -52,10 +52,12 @@ license:
   identifier: CECILL-B
 
 supported_coq_versions:
-  text: 8.16 to 8.20
-  opam: '{>= "8.16" & < "8.21"}'
+  text: 8.16 or later
+  opam: '{>= "8.16"}'
 
 tested_coq_opam_versions:
+- version: 'coq-dev'
+  repo: 'mathcomp/mathcomp-dev'
 - version: '2.2.0-coq-8.19'
   repo: 'mathcomp/mathcomp'
 - version: '2.2.0-coq-8.18'

--- a/theories/CTL/agreement.v
+++ b/theories/CTL/agreement.v
@@ -140,11 +140,11 @@ Section Paths.
   Lemma dmAU (xm : XM) w : ~ cAU R P Q w -> cER R (PredC P) (PredC Q) w.
   Proof.
     move: w. cofix dmAU => w Hw.
-    have nQw: (~ Q w). move => c. apply Hw. exact: AU0.
+    have @nQw : (~ Q w). move => c. apply Hw. exact: AU0.
     case: (xm (P w)) => [pw|nPw]; last exact: ER0.
-    suff {dmAU} [v v1 v2] : exists2 v, R w v & ~ cAU R P Q v.
+    have @ [v v1 v2] : exists2 v, R w v & ~ cAU R P Q v; last first.
       apply: ERs v1 _. exact: nQw. exact: dmAU.
-    apply: (dn xm) => C. apply: Hw. apply: AUs pw _ => v wv. 
+    apply: (dn xm) => C {nQw}. apply: Hw. apply: AUs pw _ => v wv.
     apply: (dn xm) => C'. apply: C. by exists v.
   Qed.
 
@@ -152,7 +152,7 @@ Section Paths.
   Proof.
     move => H. apply: (dn xm) => C. apply: H. 
     move: w C. cofix dmAR => w Hw.
-    have Qw : Q w. apply: (dn xm) => H. apply Hw. exact: EU0.
+    have @Qw : Q w. apply: (dn xm) => H. apply Hw. exact: EU0.
     case: (xm (P w)) => [Pw|nPw]; first exact: AR0.
     apply: ARs Qw _ => v wv. apply: dmAR => C. apply: Hw. exact: EUs C.
   Qed.
@@ -340,7 +340,7 @@ Lemma AR3_0 : cAR (@trans M3) (eval (fV 0)) (eval (fV 1)) ord0.
 Proof.
   cofix AR3_0. apply: ARs; first done. 
   case. case => [|[|n]] i. 
-  - suff ->: Ordinal i = ord0. move => _. exact: AR3_0. 
+  - have @ ->: Ordinal i = ord0; last first. move => _. exact: AR3_0.
       congr Ordinal. exact: eq_irrelevance.
   - move => _. apply: AR0 => //. 
   - move => H. case: notF. exact: contraTT H.


### PR DESCRIPTION
Due to some change in Coq (probably related to cofixpoints) some lemmas with `cofix` can't get past `Qed`. By changing `have` to `assert` and `suff` to `enough`, it works again. Since this concerns `ssr_have`, it could be related to https://github.com/coq-community/graph-theory/pull/39

Here is a sample of an error on current Coq `master` that is fixed:
```coq
Error:
Recursive definition of dmAR is ill-formed.
In environment
X : Type
R : X -> X -> Prop
P, Q : X -> Prop
R_serial : forall x : X, exists y : X, R x y
xm : XM
w : X
H : ~ cAR R P Q w
C : ~ cEU R (PredC P) (PredC Q) w
dmAR : forall w : X, ~ cEU R (PredC P) (PredC Q) w -> cAR R P Q w
w0 : X
Hw : ~ cEU R (PredC P) (PredC Q) w0
Sub-expression "ssr_have (dn xm (fun H : ~ Q w0 => Hw (EU0 R (PredC P) H)))
                  (fun Qw : Q w0 =>
                   (fun (_evar_0_ : forall a : P w0, (fun=> cAR R P Q w0) (or_introl a))
                      (_evar_0_0 : forall b : ~ P w0, (fun=> cAR R P Q w0) (or_intror b)) =>
                    match xm (P w0) as o return ((fun=> cAR R P Q w0) o) with
                    | or_introl a => _evar_0_ a
                    | or_intror b => _evar_0_0 b
                    end) ((AR0 R (w:=w0))^~ Qw)
                     (fun nPw : ~ P w0 =>
                      ARs Qw
                        (fun (v : X) (wv : R w0 v) =>
                         dmAR v (fun C : cEU R (PredC P) (PredC Q) v => Hw (EUs nPw wv C)))))" not
in guarded form (should be a constructor, an abstraction, a match, a cofix or a recursive
call).
Recursive definition is:
"fun (w : X) (Hw : ~ cEU R (PredC P) (PredC Q) w) =>
 ssr_have (dn xm (fun H : ~ Q w => Hw (EU0 R (PredC P) H)))
   (fun Qw : Q w =>
    (fun (_evar_0_ : forall a : P w, (fun=> cAR R P Q w) (or_introl a))
       (_evar_0_0 : forall b : ~ P w, (fun=> cAR R P Q w) (or_intror b)) =>
     match xm (P w) as o return ((fun=> cAR R P Q w) o) with
     | or_introl a => _evar_0_ a
     | or_intror b => _evar_0_0 b
     end) ((AR0 R (w:=w))^~ Qw)
      (fun nPw : ~ P w =>
       ARs Qw
         (fun (v : X) (wv : R w v) =>
          dmAR v (fun C : cEU R (PredC P) (PredC Q) v => Hw (EUs nPw wv C)))))".
```
and here is what the correct body looks like with `assert`:
```coq
fun (xm : XM) (w : X) (H : ~ cAR R P Q w) =>
dn xm
  (fun C : ~ cEU R (PredC P) (PredC Q) w =>
   H
     ((cofix dmAR (w0 : X) (Hw : ~ cEU R (PredC P) (PredC Q) w0) : cAR R P Q w0 :=
         let Qw : Q w0 := dn xm (fun H0 : ~ Q w0 => Hw (EU0 R (PredC P) H0)) in
         (fun (_evar_0_ : forall a : P w0, (fun=> cAR R P Q w0) (or_introl a))
            (_evar_0_0 : forall b : ~ P w0, (fun=> cAR R P Q w0) (or_intror b)) =>
          match xm (P w0) as o return ((fun=> cAR R P Q w0) o) with
          | or_introl a => _evar_0_ a
          | or_intror b => _evar_0_0 b
          end) ((AR0 R (w:=w0))^~ Qw)
           (fun nPw : ~ P w0 =>
            ARs Qw
              (fun (v : X) (wv : R w0 v) =>
               dmAR v (fun C0 : cEU R (PredC P) (PredC Q) v => Hw (EUs nPw wv C0))))) w C))
     : XM -> forall [w : X], ~ cAR R P Q w -> cEU R (PredC P) (PredC Q) w
```